### PR TITLE
fix(table): fix background color for detail row

### DIFF
--- a/src/assets/scss/components/_table.scss
+++ b/src/assets/scss/components/_table.scss
@@ -363,7 +363,7 @@ $table-card-margin: 0 0 1rem 0;
 
         &-detail {
             box-shadow: h.useVar("table-tr-detail-box-shadow");
-            background-color: h.useVar("table-tr-detail-background");
+            background-color: h.useVar("table-tr-detail-background-color");
 
             & > td {
                 padding: h.useVar("table-tr-detail-padding");


### PR DESCRIPTION
Closes #130 

Fixes the background color being undefined due to a typo in the background colour variable.
To test use the following steps in the example environment:
1. Go to the table component -> Detailed.
2. Uncheck custom detail row.
3. Verify that the background colour of the detail row is no longer white.


Before:
<img width="1467" height="787" alt="image" src="https://github.com/user-attachments/assets/5babf00d-ad8a-4272-804e-345699b3aa6e" />


After:
<img width="1472" height="798" alt="image" src="https://github.com/user-attachments/assets/1f4242c6-f210-439c-92f8-4cdd192060ee" />
