### PR TITLE
fix(control): solve control-focus-box-shadow not being customisable

### DIFF
--- a/src/assets/scss/utils/_helpers.scss
+++ b/src/assets/scss/utils/_helpers.scss
@@ -160,7 +160,7 @@
         &:focus-visible,
         &:focus-within {
             #{$selector} {
-                box-shadow: vars.$control-focus-box-shadow useVar("focus");
+                box-shadow: useVar("control-focus-box-shadow") useVar("focus");
                 outline: none;
             }
         }

--- a/src/assets/scss/utils/_root.scss
+++ b/src/assets/scss/utils/_root.scss
@@ -75,6 +75,10 @@ $host-selector: if(vars.$enable-host, ":root, :host", ":root");
         vars.$control-box-shadow-inset
     );
     @include h.defineVar(
+        "control-focus-box-shadow",
+        vars.$control-focus-box-shadow
+    );
+    @include h.defineVar(
         "control-brackground-color",
         vars.$control-brackground-color
     );


### PR DESCRIPTION
Closes #132 

Fixes the issue by adding the variable to the root and making the helper use the defined variable. That way it can also be user defined.

The easiest way to test that this works is to go to the input examples and for one of the input fields add the `--oruga-control-focus-box-shadow: none` style in the inspector. Then observe that that input field no longer has a box shadow when hovering or focussing it.