### PR TITLE
fix(pagination): fix button styling

### DIFF
--- a/src/assets/scss/components/_pagination.scss
+++ b/src/assets/scss/components/_pagination.scss
@@ -178,6 +178,7 @@ $pagination-button-current-border-color: h.useVar("primary") !default;
         padding: h.useVar("pagination-button-padding");
         margin: h.useVar("pagination-spacer");
 
+        &:focus,
         &:hover {
             color: h.useVar("pagination-button-hover-color");
             border-color: h.useVar("pagination-button-hover-border-color");
@@ -194,7 +195,7 @@ $pagination-button-current-border-color: h.useVar("primary") !default;
         }
 
         &--disabled {
-            @include h.disabled(h.useVar("menu-disabled-opacity"));
+            @include h.disabled(h.useVar("control-disabled-opacity"));
         }
 
         &--current {


### PR DESCRIPTION
Closes #134 

Fixes 2 issues with the pagination button styling:
- Adds opacity back to disabled pagination button:
- Makes the focus style of the pagination button match the hover style.

Both of these can easily be tested in the pagination page of the example environment.

An alternative for the focus style could also be to remove the focus style from the normal button. That way clicking doesn't make it feel like the hover is always active. This would have my preference if possible.