### PR TITLE
fix(table): fix detail chevron header width

### DIFF
--- a/src/assets/scss/components/_table.scss
+++ b/src/assets/scss/components/_table.scss
@@ -449,7 +449,7 @@ $table-card-margin: 0 0 1rem 0;
         }
 
         &-detailed {
-            width: h.useVar("table-th-detail-width");
+            width: h.useVar("table-td-detail-chevron-width");
         }
     }
 


### PR DESCRIPTION
Closes #140 by setting the width of the th to be the same as the chevron td. 