### PR TITLE
fix(css): fix variable naming errors

### DIFF
--- a/src/assets/scss/components/_icon.scss
+++ b/src/assets/scss/components/_icon.scss
@@ -22,8 +22,8 @@ $icon-spin-animation-duration: 2s !default;
     color: h.useVar("icon-color");
     font-size: h.useVar("icon-font-size");
     transition:
-        transform h.useVar("animation-speed-fast") h.useVar("animation-timing"),
-        opacity h.useVar("animation-speed") h.useVar("animation-timing");
+        transform h.useVar("animation-speed-fast") h.useVar("transition-timing"),
+        opacity h.useVar("animation-speed") h.useVar("transition-timing");
 
     // size variants
     @each $name, $value in vars.$sizes {

--- a/src/assets/scss/components/_table.scss
+++ b/src/assets/scss/components/_table.scss
@@ -35,9 +35,9 @@ $table-th-checkbox-width: 40px !default;
 $table-th-padding: h.useVar("control-spacer")
     calc(1.5 * h.useVar("control-spacer")) !default;
 
-$table-th-current-sort-border-color: h.useVar("grey") !default;
-$table-th-current-sort-font-weight: 700 !default;
-$table-th-current-sort-hover-border-color: h.useVar("grey") !default;
+$table-th-sorted-border-color: h.useVar("grey") !default;
+$table-th-sorted-font-weight: 700 !default;
+$table-th-sorted-hover-border-color: h.useVar("grey") !default;
 
 $table-td-border-width: h.useVar("control-border-width") !default;
 $table-td-border-style: solid !default;
@@ -123,16 +123,16 @@ $table-card-margin: 0 0 1rem 0;
         @include h.defineVar("table-th-padding", $table-th-padding);
 
         @include h.defineVar(
-            "table-th-current-sort-border-color",
-            $table-th-current-sort-border-color
+            "table-th-sorted-border-color",
+            $table-th-sorted-border-color
         );
         @include h.defineVar(
-            "table-th-current-sort-font-weight",
-            $table-th-current-sort-font-weight
+            "table-th-sorted-font-weight",
+            $table-th-sorted-font-weight
         );
         @include h.defineVar(
-            "table-th-current-sort-hover-border-color",
-            $table-th-current-sort-hover-border-color
+            "table-th-sorted-hover-border-color",
+            $table-th-sorted-hover-border-color
         );
 
         @include h.defineVar("table-td-border-width", $table-td-border-width);
@@ -426,10 +426,10 @@ $table-card-margin: 0 0 1rem 0;
             width: h.useVar("table-th-checkbox-width");
         }
 
-        &-current-sort,
-        &--current-sort {
-            border-color: h.useVar("table-th-current-sort-border-color");
-            font-weight: h.useVar("table-th-current-sort-font-weight");
+        &-sorted,
+        &--sorted {
+            border-color: h.useVar("table-th-sorted-border-color");
+            font-weight: h.useVar("table-th-sorted-font-weight");
         }
 
         &--sortable {
@@ -437,9 +437,7 @@ $table-card-margin: 0 0 1rem 0;
             @include h.clickable;
 
             &:hover {
-                border-color: h.useVar(
-                    "table-th-current-sort-hover-border-color"
-                );
+                border-color: h.useVar("table-th-sorted-hover-border-color");
             }
         }
 

--- a/src/assets/scss/components/_table.scss
+++ b/src/assets/scss/components/_table.scss
@@ -247,7 +247,7 @@ $table-card-margin: 0 0 1rem 0;
 
     &__wrapper {
         transition: opacity h.useVar("animation-speed")
-            h.useVar("animation-timing");
+            h.useVar("transition-timing");
         position: relative;
 
         &--sticky-header {

--- a/src/assets/scss/components/_tabs.scss
+++ b/src/assets/scss/components/_tabs.scss
@@ -170,7 +170,7 @@ $tabs-content-padding: calc(2 * h.useVar("control-spacer")) !default;
                     h.useVar("tabs-tab-hover-background-color")
                 );
                 @include h.defineVar(
-                    "tabs-tab-bottom-color",
+                    "tabs-tab-border-color",
                     h.useVar("tabs-tab-hover-border-color")
                 );
             }

--- a/src/assets/scss/utils/_animations.scss
+++ b/src/assets/scss/utils/_animations.scss
@@ -128,7 +128,7 @@
 .fade-enter-active,
 .fade-leave-active {
     transition: opacity h.useVar("animation-speed-fast")
-        h.useVar("animation-timing");
+        h.useVar("transition-timing");
 }
 
 .fade-enter,
@@ -141,11 +141,11 @@
 .zoom-in-enter-active,
 .zoom-in-leave-active {
     transition: opacity h.useVar("animation-speed-fast")
-        h.useVar("animation-timing");
+        h.useVar("transition-timing");
 
     .animation-content {
         transition: transform h.useVar("animation-speed-fast")
-            h.useVar("animation-timing");
+            h.useVar("transition-timing");
     }
 }
 
@@ -163,11 +163,11 @@
 .zoom-out-enter-active,
 .zoom-out-leave-active {
     transition: opacity h.useVar("animation-speed-fast")
-        h.useVar("animation-timing");
+        h.useVar("transition-timing");
 
     .animation-content {
         transition: transform h.useVar("animation-speed-fast")
-            h.useVar("animation-timing");
+            h.useVar("transition-timing");
     }
 }
 
@@ -231,11 +231,11 @@
 }
 
 .slide-enter-active {
-    transition: h.useVar("animation-speed-fast") h.useVar("animation-timing");
+    transition: h.useVar("animation-speed-fast") h.useVar("transition-timing");
 }
 
 .slide-leave-active {
-    transition: h.useVar("animation-speed-fast") h.useVar("animation-timing");
+    transition: h.useVar("animation-speed-fast") h.useVar("transition-timing");
     transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
 


### PR DESCRIPTION
A few css variables had outdated names causing certain parts of the styling to not work:

- The `current-sort` class was replaced with the `sorted` class to match the change in Oruga itself. This caused there to be no styling change in the `th` when the column was sorted

- Inside _animations.scss the `animation-timing` variable was being used when only the `transition-timing` variable has been defined. This caused animations like the slide for `o-collapse` to not work at all as the timing would be undefined.

- The variable `tabs-tab-hover-border-color` was being assigned to `tabs-tab-bottom-color` instead of `tabs-tab-border-color` when a tab was being hovered over. This caused the `tabs-tab-hover-border-color` to have no effect.